### PR TITLE
Add a warning about using string interpolation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,7 +29,18 @@ Add the following to your Gemfile:
 
   gem 'coffee-filter'
 
+=== Caveats
+Using Ruby interpolation within the +:coffeescript+ block will prevent Haml from caching the result of compilation.
+This means that your coffeescript block will be compiled by the coffeescript engine on runtime during every request,
+which is something you'll definitely want to avoid (since it's orders of magnitude slower).
+
+In other words, using constructs similar to this:
+
+  :coffeescript
+    @server_time = #{Time.now.to_i}
+
+will cost you around 100ms on each request. Either use the +:javascript+ filter for this,
+or embed the dynamic content in some other way in the DOM.
+
 
 Copyright (c) 2011 Paul Nicholson, released under the MIT license
-
-


### PR DESCRIPTION
We've noticed that several `:coffeescript` blocks cost us a lot of precious response time in production. After digging into the issue, we've noticed that HAML won't cache the result of `Coffeescript.compile(text)` if the block contains Ruby string interpolation.

Hopefully, this note will warn others.
