### PR TITLE
add license information to the gemspec

### DIFF
--- a/coffee-filter.gemspec
+++ b/coffee-filter.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  s.license = "MIT"
 end


### PR DESCRIPTION
Please add this information so that we can get that from rubygems.org API.
